### PR TITLE
Base Entity 구현

### DIFF
--- a/auth-server/src/main/resources/application.yml
+++ b/auth-server/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    include: core
+
   # .env import
   config:
     import: optional:file:./auth-server/.env[.properties]

--- a/core/src/main/java/com/yhkim/entity/BaseEntity.java
+++ b/core/src/main/java/com/yhkim/entity/BaseEntity.java
@@ -1,0 +1,31 @@
+package com.yhkim.entity;
+
+
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "DATE")
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at", columnDefinition = "DATE")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at", columnDefinition = "DATE")
+	private LocalDateTime deletedAt;
+}
+
+

--- a/core/src/main/resources/application-core.yml
+++ b/core/src/main/resources/application-core.yml
@@ -1,16 +1,4 @@
 spring:
-  # .env import
-  config:
-    import: optional:file:.env[.properties]
-
-  # DB
-  datasource:
-    url: jdbc:mariadb://${DB_HOST}:${DB_PORT}/${DB_NAME}
-    username: ${DB_USER}
-    password: ${DB_PASSWORD}
-    driver-class-name: org.mariadb.jdbc.Driver
-
   jpa:
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MariaDBDialect
+    hibernate:
+      ddl-auto: create

--- a/resource-server/src/main/resources/application.yml
+++ b/resource-server/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    include: core
+
   # .env import
   config:
     import: optional:file:./resource-server/.env[.properties]


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- (기능에서 어떤 부분이 구현되었는지 설명해주세요)
- BaseEntity 클래스를 생성하여 공통 속성을 담고, 엔티티가 상속받을 수 있도록 하였습니다.
현재 ERD가 아래와 같아 
3개의 테이블의 공통 속성인 id, created_at, updated_at, deleted_at 을 추가하였습니다.
![금사파 ERD (2)](https://github.com/user-attachments/assets/ee0fbd1b-6f85-4a6c-985a-b1cbb566b61c)

prduct_price 테이블은 상속받지 않고 따로 구현할 예정입니다. 

<br/>

## 🌱 관련 이슈 (필수)
- (관련 이슈 번호를 작성해주세요) 
- close #7 

<br/> 

## 📚 기타 (선택) 
- (그 외 참고할 만한 내용이 있다면 작성해주세요)


> **@MappedSuperclass**
BaseEntity를 상속받은 자식 클래스에게, 부모 클래스의 매핑 정보를 모두 제공해주는 어노테이션입니다. 해당 어노테이션은 Entity로 인식되지 않으며, 데이터베이스에 테이블이 생성되지 않습니다.
이 어노테이션으로 인하여, 상속받은 자식 클래스는 모두 공통 속성을 지니게 됩니다.

> **@EntityListeners(AuditingEntityListener.class)**
JPA Auditing 기능을 사용하려면, application 클래스에 @EnableJpaAuditing을 붙여주어야 사용이 가능합니다.
AuditingEntityListener 클래스는 엔티티의 생성, 수정, 삭제 등의 이벤트가 발생하였을 때, 이와 같은 엔티티의 변경 사항을 Audit(감사)하기 위한 클래스입니다. 해당 어노테이션으로 리스너 클래스를 등록하여, 엔티티에 대한 이벤트가 발생하였을 때, 이벤트에 대한 처리를 진행할 수 있습니다.
따라서, @CreateDate와 @LastModifiedDate를 적용하여, 엔티티의 생성일과 마지막 수정일을 간편하게 관리할 수 있습니다.

> 참고 : [[Spring] 공통 필드 하나로 묶기! || BaseEntity, JpaAuditing](https://dmaolon00.tistory.com/entry/Spring-%EA%B3%B5%ED%86%B5-%ED%95%84%EB%93%9C-%ED%95%98%EB%82%98%EB%A1%9C-%EB%AC%B6%EA%B8%B0-BaseEntity-JpaAuditing)

<br/>
